### PR TITLE
bmWebSocket 文档需更新

### DIFF
--- a/zh-cn/eros_sdk_module.md
+++ b/zh-cn/eros_sdk_module.md
@@ -829,9 +829,138 @@ tools.scan(function(resDate){
 ```
 
 # bmWebSocket
-bmbmWebSocket用于创建一个webSocket会话，api和使用方式与[weex官方WebSocket](http://weex.apache.org/cn/references/modules/websocket.html)。
-### 引用方式 
-`var bmWebSocket = weex.requireModule('bmWebSocket')`
+bmbmWebSocket用于创建一个webSocket会话
+调用方法如下：
+
+```js
+<template>
+  <scroller>
+    <div>
+      <div style="background-color: #286090">
+        <text class="title" style="height: 80px ;padding: 20px;color: white">websocket</text>
+      </div>
+      <input type="text" placeholder="please input message to send" class="input" autofocus="false" value="" @change="onchange" @input="oninput" ref="input"/>
+      <div style="flex-direction: row; justify-content: center;">
+        <text class="button" @click="connect">connect</text>
+        <text class="button" @click="send">send</text>
+        <text class="button" @click="close">close</text>
+      </div>
+
+      <div style="background-color: lightgray">
+        <text class="title" style="height: 80px ;padding: 20px;color: black">method = send</text>
+      </div>
+      <text style="color: black;height: 80px">{{sendinfo}}</text>
+
+
+      <div style="background-color: lightgray">
+        <text class="title" style="height: 80px ;padding: 20px;color: black">method = onopen</text>
+      </div>
+      <text style="color: black;height: 80px">{{onopeninfo}}</text>
+
+      <div style="background-color: lightgray">
+        <text class="title" style="height: 80px ;padding: 20px;color: black">method = onmessage</text>
+      </div>
+      <text style="color: black;height: 400px">{{onmessage}}</text>
+
+      <div style="background-color: lightgray">
+        <text class="title" style="height: 80px ;padding: 20px;color: black">method = onclose</text>
+      </div>
+      <text style="color: black;height: 80px">{{oncloseinfo}}</text>
+
+      <div style="background-color: lightgray">
+        <text class="title" style="height: 80px ;padding: 20px;color: black">method = onerror</text>
+      </div>
+      <text style="color: black;height: 80px">{{onerrorinfo}}</text>
+
+      <div style="background-color: lightgray">
+        <text class="title" style="height: 80px ;padding: 20px;color: black">method = close</text>
+      </div>
+      <text style="color: black;height: 80px">{{closeinfo}}</text>
+
+    </div>
+
+  </scroller>
+</template>
+
+<style scoped>
+  .input {
+    font-size: 40px;
+    height: 80px;
+    width: 600px;
+  }
+  .button {
+    font-size: 36px;
+    width: 150px;
+    color: #41B883;
+    text-align: center;
+    padding-top: 25px;
+    padding-bottom: 25px;
+    border-width: 2px;
+    border-style: solid;
+    margin-right: 20px;
+    border-color: rgb(162, 217, 192);
+    background-color: rgba(162, 217, 192, 0.2);
+  }
+</style>
+<script>
+  var bmWebSocket = weex.requireModule('bmWebSocket')
+  export default {
+    data () {
+      return {
+        connectinfo: '',
+        sendinfo: '',
+        onopeninfo: '',
+        onmessage: '',
+        oncloseinfo: '',
+        onerrorinfo: '',
+        closeinfo: '',
+        txtInput:'',
+        navBarHeight: 88,
+        title: 'Navigator',
+        dir: 'examples',
+        baseURL: ''
+      }
+    },
+    methods: {
+      connect:function() {
+        bmWebSocket.WebSocket('ws://echo.websocket.org','');
+        var self = this;
+        self.onopeninfo = 'connecting...'
+        bmWebSocket.onopen(function(e)
+        {
+          self.onopeninfo = 'websocket open';
+        });
+        bmWebSocket.onmessage(function(e)
+        {
+          self.onmessage = e.data;
+        });
+        bmWebSocket.onerror(function(e)
+        {
+          self.onerrorinfo = e.data;
+        })
+        bmWebSocket.onclose(function(e)
+        {
+          self.onopeninfo = '';
+          self.onerrorinfo = e.code;
+        })
+      },
+      send:function(e) {
+        var input = this.$refs.input;
+        input.blur();
+        bmWebSocket.send(this.txtInput);
+        this.sendinfo = this.txtInput;
+      },
+      oninput: function(event) {
+        this.txtInput = event.value;
+      },
+      close:function(e) {
+        bmWebSocket.close();
+      },
+    },
+  }
+</script>
+```
+
 ### API
 #### webSocket(url, protocol)
 创建 WebSockets，并连接服务器

--- a/zh-cn/eros_sdk_module.md
+++ b/zh-cn/eros_sdk_module.md
@@ -830,7 +830,32 @@ tools.scan(function(resDate){
 
 # bmWebSocket
 bmbmWebSocket用于创建一个webSocket会话
-调用方法如下：
+
+### API
+**引用方式**
+
+```js
+var bmWebSocket = weex.requireModule('bmWebSocket')
+```
+
+#### webSocket(url, protocol)
+创建 WebSockets，并连接服务器
+
+#### send(data)
+通过WebSocket连接向服务器发送数据
+
+#### close(code,reason)
+关闭 WebSockets 的链接
+#### onopen
+链接打开的监听
+#### onmessage(options)
+消息事件的监听器
+#### onclose(options)
+关闭事件的监听器
+#### onerror(options)
+错误事件的监听器
+
+bmWebSocket 具体范例如下：
 
 ```js
 <template>
@@ -937,12 +962,12 @@ bmbmWebSocket用于创建一个webSocket会话
         bmWebSocket.onerror(function(e)
         {
           self.onerrorinfo = e.data;
-        })
+        });
         bmWebSocket.onclose(function(e)
         {
           self.onopeninfo = '';
           self.onerrorinfo = e.code;
-        })
+        });
       },
       send:function(e) {
         var input = this.$refs.input;
@@ -960,26 +985,6 @@ bmbmWebSocket用于创建一个webSocket会话
   }
 </script>
 ```
-
-### API
-#### webSocket(url, protocol)
-创建 WebSockets，并连接服务器
-
-#### send(data)
-通过WebSocket连接向服务器发送数据
-
-#### close(code,reason)
-关闭 WebSockets 的链接
-#### onopen
-链接打开的监听
-#### onmessage(options)
-消息事件的监听器
-#### onclose(options)
-关闭事件的监听器
-#### onerror(options)
-错误事件的监听器
-
-
 
 
 


### PR DESCRIPTION
因为之前指向的 weex 官方文档的写法已经失效，最近几个版本的写法需要做出调整，把赋值的等号改成括号写法，否则会导致无法正常使用，前端收不到服务端的任何消息。

原先官方写法如下（已经失效）：
webSocket.onopen = function (e) {
      console.log('onopen', e);
};

改成如下格式能正常运行：
webSocket.onopen( function (e) {
      console.log('onopen', e);
});